### PR TITLE
Remove logo and skywalking dev mail list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # SkyWalking Node.js
 
-<img src="https://skywalkingtest.github.io/page-resources/3.0/skywalking.png" alt="Sky Walking logo" height="90px" align="right" />
-
 SkyWalking Node.js is the Node.js instrumentation agent, which is compatible with [Apache SkyWalking(Incubating) APM](https://github.com/apache/incubator-skywalking) backend and others compatible agents/SDKs.
 
 [![Build Status](https://travis-ci.org/OpenSkywalking/skywalking-nodejs.svg?branch=master)](https://travis-ci.org/OpenSkywalking/skywalking-nodejs)
@@ -17,8 +15,6 @@ SkyWalking Node.js is the Node.js instrumentation agent, which is compatible wit
 
 # Contact Us
 * Submit an issue
-* Mail list: dev@skywalking.apache.org
-* [Gitter](https://gitter.im/openskywalking/Lobby)
 * QQ Group: 392443393
 
 ## License


### PR DESCRIPTION
@ascrutae Since you have not decided the solution, I just try to remove the SkyWalking logo first.
I hope we could deal with the trademark and branding issue as soon as possible.