### PR TITLE
change host to hostname

### DIFF
--- a/modules/nodejs-agent/lib/plugins/http/http.js
+++ b/modules/nodejs-agent/lib/plugins/http/http.js
@@ -94,7 +94,7 @@ module.exports = function(httpModule, instrumentation, contextManager) {
     function wrapRequest(original) {
         return function(options, callback) {
             let contextCarrier = new ContextCarrier();
-            let span = contextManager.createExitSpan(options.path, options.host + ":" + options.port, contextCarrier);
+            let span = contextManager.createExitSpan(options.path, options.hostname + ":" + options.port, contextCarrier);
             contextCarrier.pushBy(function(key, value) {
                 if (!options.hasOwnProperty("headers")) {
                     options.headers = {};


### PR DESCRIPTION
It‘s best to use `hostname`，because `host` may ba has a port.