### PR TITLE
fix headers may be null value at some situation

### DIFF
--- a/modules/nodejs-agent/lib/plugins/http/http.js
+++ b/modules/nodejs-agent/lib/plugins/http/http.js
@@ -96,7 +96,7 @@ module.exports = function(httpModule, instrumentation, contextManager) {
             let contextCarrier = new ContextCarrier();
             let span = contextManager.createExitSpan(options.path, options.host + ":" + options.port, contextCarrier);
             contextCarrier.pushBy(function(key, value) {
-                if (!options.hasOwnProperty("headers")) {
+                if (!options.hasOwnProperty("headers") || !options.headers) {
                     options.headers = {};
                 }
                 options.headers[key] = value;


### PR DESCRIPTION
when use mongoose-elasticsearch-xp to update some entities, the options.headers value is null