### PR TITLE
Fix wrong OS info key name

### DIFF
--- a/modules/nodejs-agent/lib/services/register-service.js
+++ b/modules/nodejs-agent/lib/services/register-service.js
@@ -64,7 +64,7 @@ RegisterService.prototype.launch = function() {
                             host_name: os.hostname(),
                             process_no: process.pid + "",
                             language: "nodejs",
-                            ipV4s: getAllIPv4Address(),
+                            ipv4: getAllIPv4Address(),
                         },
                         instanceUUID: function() {
                             return agentConfig.instanceUUID();


### PR DESCRIPTION
This key is the same in the new protocol, so I'd like to sync it back to the master branch, otherwise the service instance ip is always empty