### PR TITLE
fix: skyapm-egg-require failed to parse npm command args

### DIFF
--- a/modules/skyapm-egg-require/index.js
+++ b/modules/skyapm-egg-require/index.js
@@ -18,7 +18,7 @@
 "use strict";
 
 const argString = process.argv.slice(2);
-const args = JSON.parse(!argString && argString.length > 0 ? argString : "{}");
+const args = JSON.parse(argString && argString.length > 0 ? argString : "{}");
 let serviceName;
 let directServers;
 let authentication;


### PR DESCRIPTION
accidentally add an extra '!'