### PR TITLE
BugFix: stacked spans are not correctly cleared

### DIFF
--- a/modules/nodejs-agent/lib/cache/index.js
+++ b/modules/nodejs-agent/lib/cache/index.js
@@ -17,17 +17,17 @@
 "use strict";
 
 /**
- *
+ * @class TraceSegmentCachePool
  * @constructor
  * @author zhang xin
  */
 function TraceSegmentCachePool() {
     this._bucket = [];
-    this._bucketSize = Number.isSafeInteger(256);
+    this._bucketSize = 256;
     this._timeout = undefined;
     this._consumer = undefined;
     this._flushInterval = 1000;
-};
+}
 
 TraceSegmentCachePool.prototype.put = function(traceSegment) {
     this._bucket.push(traceSegment);
@@ -39,7 +39,7 @@ TraceSegmentCachePool.prototype.put = function(traceSegment) {
 };
 
 TraceSegmentCachePool.prototype.consumeData = function() {
-    if (this._bucket.length != 0) {
+    if (this._bucket.length !== 0) {
         this._consumer(this._bucket);
     }
     this._clear();

--- a/modules/nodejs-agent/lib/trace/context-manager.js
+++ b/modules/nodejs-agent/lib/trace/context-manager.js
@@ -59,7 +59,7 @@ ContextManager.prototype.inject = function(contextCarrier) {
         return;
     }
 
-    this._activeTraceContext.inject.apply(activeTraceContext, [contextCarrier]);
+    this._activeTraceContext.inject.apply(this._activeTraceContext, [contextCarrier]);
 };
 
 ContextManager.prototype.extract = function(contextCarrier) {
@@ -72,8 +72,11 @@ ContextManager.prototype.extract = function(contextCarrier) {
 
 ContextManager.prototype.finishSpan = function(span) {
     let finishTraceContext = span.traceContext();
-    finishTraceContext.finish(span);
-    this.active(finishTraceContext.parentTraceContext.apply(finishTraceContext, []));
+    if (finishTraceContext.finish(span)) {
+        this.active(undefined);
+    } else {
+        this.active(finishTraceContext.parentTraceContext.apply(finishTraceContext, []));
+    }
 };
 
 ContextManager.prototype.active = function(traceContext) {
@@ -99,7 +102,7 @@ ContextManager.prototype.createEntrySpan = function(
     this.active(span.traceContext());
 
     if (contextCarrier) {
-        span.traceContext().extract.apply(span.traceContext(), [contextCarrier, this._agentConfig]);
+        span.traceContext().extract.apply(span.traceContext(), [contextCarrier]);
     }
 
     return span;

--- a/modules/nodejs-agent/lib/trace/trace-segment.js
+++ b/modules/nodejs-agent/lib/trace/trace-segment.js
@@ -27,6 +27,7 @@ const TraceCommonParameteres = require("../network/common/trace-common_pb");
 const TraceSegmentParameteres = require("../network/language-agent-v2/trace_pb");
 
 /**
+ * @class TraceSegment
  * @author zhang xin
  */
 function TraceSegment() {
@@ -46,9 +47,11 @@ TraceSegment.prototype.traceSegmentId = function() {
 TraceSegment.prototype.archive = function(span) {
     this._finishedSpan.push(span);
 
-    if ((--this._runningSpanSize) == 0) {
+    if ((--this._runningSpanSize) === 0) {
         this.finish();
+        return true;
     }
+    return false;
 };
 
 TraceSegment.prototype.finish = function() {
@@ -57,7 +60,7 @@ TraceSegment.prototype.finish = function() {
 
 TraceSegment.prototype.generateSpanId = function(spanOptions, callback) {
     this._runningSpanSize++;
-    if (this._spanIdGenerator == 0) {
+    if (this._spanIdGenerator === 0) {
         if (spanOptions["operationName"]) {
             this._entryOperationName = spanOptions["operationName"];
         } else {


### PR DESCRIPTION
This patch fixes the bug that I've reported to @ascrutae and @wu-sheng via direct messages, that is, all the spans share the same trace context (thus same trace id) after running a while.

After debugging in my application, it turns out that one (or more) trace context(s) is/are not correctly cleared when it/they should be, this patch is tested and it fixes the issue I reported before.