### PR TITLE
Support enabling/disabling the agent via env var

### DIFF
--- a/modules/nodejs-agent/lib/agent.js
+++ b/modules/nodejs-agent/lib/agent.js
@@ -33,6 +33,10 @@ function Agent() {
 }
 
 Agent.prototype.start = function(agentOptions) {
+    if (!!process.env.SW_ENABLED && process.env.SW_ENABLED !== "true") {
+        console.info("SW_ENABLED != true, the agent won't start");
+        return;
+    }
     AgentConfig.initConfig(agentOptions);
     serviceManager.launch();
 
@@ -45,7 +49,7 @@ Agent.prototype.start = function(agentOptions) {
         function(originModule, moduleName, version, enhanceFile) {
             let intercept = _pluginManager.attemptToFindInterceptor(moduleName, version, enhanceFile);
 
-            if (intercept == undefined) {
+            if (intercept === undefined) {
                 return originModule;
             }
 


### PR DESCRIPTION
Most of the other language agents support disabling the agent by simply removing jars or setting env variable, this patch supports enabling/disabling the agent via environment variable `SW_ENABLED`, this is useful especially when the `npm build` takes a long time and the agent is not very stable now