### PR TITLE
Move end of http request span to correct location.

### DIFF
--- a/modules/nodejs-agent/lib/plugins/http/http.js
+++ b/modules/nodejs-agent/lib/plugins/http/http.js
@@ -104,7 +104,11 @@ module.exports = function(httpModule, instrumentation, contextManager) {
             span.component(componentDefine.Components.HTTP);
             span.spanLayer(layerDefine.Layers.HTTP);
             let result = original.apply(this, arguments);
-            contextManager.finishSpan(span);
+            result.once("response", function(res) {
+              res.once("end", function() {
+                contextManager.finishSpan(span);
+              });
+            });
             return result;
         };
     }


### PR DESCRIPTION
Currently the end of http request span is in wrong location, it ends immediately after ClientRequest instance created;
The http span should contain the whole request, ends after the response is fully transfered. So I move it to "end" event of the response.